### PR TITLE
Improve Auth forms

### DIFF
--- a/src/app/Auth/Login.tsx
+++ b/src/app/Auth/Login.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import * as Yup from "yup";
 import { Link, Redirect } from "react-router-dom";
 import { Button, Alert } from "antd";
-import { Formik, FormikProps } from "formik";
+import { Formik, FormikProps, Form } from "formik";
 
 import { INVENTORY, REQUEST_RESET, REGISTER } from "routes";
 import { LoginSpecs } from "./types";
@@ -49,7 +49,6 @@ const LoginPage: React.FC<LoginSpecs.Props> = ({ login, history }) => {
           values,
           errors,
           setFieldValue,
-          submitForm,
           submitCount,
           isSubmitting,
         } = props;
@@ -67,41 +66,43 @@ const LoginPage: React.FC<LoginSpecs.Props> = ({ login, history }) => {
                     style={{ marginBottom: '16px' }}
                   />
                 )}
-                <Input
-                  label="Email/Username"
-                  value={values.emailOrUsername}
-                  error={wasSubmitted && !!errors.emailOrUsername}
-                  errorMsg={errors.emailOrUsername}
-                  autocomplete="emailOrUsername"
-                  onChange={(v) => setFieldValue("emailOrUsername", v)}
-                />
+                <Form>
+                  <Input
+                    label="Email/Username"
+                    value={values.emailOrUsername}
+                    error={wasSubmitted && !!errors.emailOrUsername}
+                    errorMsg={errors.emailOrUsername}
+                    autocomplete="emailOrUsername"
+                    onChange={(v) => setFieldValue("emailOrUsername", v)}
+                  />
 
-                <Input
-                  label="Password"
-                  value={values.password}
-                  error={wasSubmitted && !!errors.password}
-                  errorMsg={errors.password}
-                  autocomplete="current-password"
-                  onChange={(v) => setFieldValue("password", v)}
-                  type="password"
-                />
+                  <Input
+                    label="Password"
+                    value={values.password}
+                    error={wasSubmitted && !!errors.password}
+                    errorMsg={errors.password}
+                    autocomplete="current-password"
+                    onChange={(v) => setFieldValue("password", v)}
+                    type="password"
+                  />
 
-                <div style={{ marginTop: "32px" }}>
-                  <Button
-                    size="large"
-                    type="primary"
-                    block={true}
-                    disabled={isSubmitting}
-                    onClick={submitForm}
-                  >
-                    Sign In
-                  </Button>
-                </div>
+                  <div style={{ marginTop: "32px" }}>
+                    <Button
+                      size="large"
+                      htmlType="submit"
+                      type="primary"
+                      block={true}
+                      disabled={isSubmitting}
+                    >
+                      Sign In
+                    </Button>
+                  </div>
 
-                <BottomTray>
-                  <Link to={REGISTER}>Register</Link>
-                  <Link to={REQUEST_RESET}>Reset Password</Link>
-                </BottomTray>
+                  <BottomTray>
+                    <Link to={REGISTER}>Register</Link>
+                    <Link to={REQUEST_RESET}>Reset Password</Link>
+                  </BottomTray>
+                </Form>
               </Box>
             </AuthWrapper>
           </AuthPage>

--- a/src/app/Auth/Login.tsx
+++ b/src/app/Auth/Login.tsx
@@ -64,6 +64,7 @@ const LoginPage: React.FC<LoginSpecs.Props> = ({ login, history }) => {
                   <Alert
                     message="Invalid email/username or password. Please try again."
                     type="error"
+                    style={{ marginBottom: '16px' }}
                   />
                 )}
                 <Input

--- a/src/app/Auth/Register.tsx
+++ b/src/app/Auth/Register.tsx
@@ -53,7 +53,11 @@ const RegistrationPage: React.FC<RegisterSpecs.Props> = ({ register, history }) 
                             <Box>
                                 <h1>Create Account</h1>
                                 {authError && (
-                                    <Alert message="Username/email already registered. Please login." type="error"/>
+                                    <Alert
+                                        message="Username/email already registered. Please login."
+                                        type="error"
+                                        style={{ marginBottom: '16px' }}
+                                    />
                                 )}
                                 <Input label="Username"
                                        value={values.username}

--- a/src/app/Auth/Register.tsx
+++ b/src/app/Auth/Register.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Link } from "react-router-dom";
 import * as Yup from 'yup';
 import { Button, Alert } from 'antd';
-import { Formik, FormikProps } from 'formik';
+import { Formik, FormikProps, Form } from 'formik';
 
 import { INVENTORY, LOGIN, REQUEST_RESET } from "routes";
 import { RegisterSpecs } from "./types";
@@ -44,7 +44,7 @@ const RegistrationPage: React.FC<RegisterSpecs.Props> = ({ register, history }) 
             })}
         >
             {(props: FormikProps<RegisterSpecs.FormValues>) => {
-                const { values, errors, setFieldValue, submitForm, submitCount, isSubmitting } = props;
+                const { values, errors, setFieldValue, submitCount, isSubmitting } = props;
                 const wasSubmitted = submitCount > 0;
 
                 return (
@@ -59,41 +59,43 @@ const RegistrationPage: React.FC<RegisterSpecs.Props> = ({ register, history }) 
                                         style={{ marginBottom: '16px' }}
                                     />
                                 )}
-                                <Input label="Username"
-                                       value={values.username}
-                                       error={wasSubmitted && !!errors.username}
-                                       errorMsg={errors.username}
-                                       autocomplete="off"
-                                       onChange={v => setFieldValue('username', v)}/>
+                                <Form>
+                                    <Input label="Username"
+                                           value={values.username}
+                                           error={wasSubmitted && !!errors.username}
+                                           errorMsg={errors.username}
+                                           autocomplete="off"
+                                           onChange={v => setFieldValue('username', v)}/>
 
-                                <Input label="Email"
-                                       value={values.email}
-                                       error={wasSubmitted && !!errors.email}
-                                       errorMsg={errors.email}
-                                       autocomplete="off"
-                                       onChange={v => setFieldValue('email', v)}/>
+                                    <Input label="Email"
+                                           value={values.email}
+                                           error={wasSubmitted && !!errors.email}
+                                           errorMsg={errors.email}
+                                           autocomplete="off"
+                                           onChange={v => setFieldValue('email', v)}/>
 
-                                <Input label="Password"
-                                       value={values.password}
-                                       type="password"
-                                       error={wasSubmitted && !!errors.password}
-                                       errorMsg={errors.password}
-                                       autocomplete="off"
-                                       onChange={v => setFieldValue('password', v)}/>
+                                    <Input label="Password"
+                                           value={values.password}
+                                           type="password"
+                                           error={wasSubmitted && !!errors.password}
+                                           errorMsg={errors.password}
+                                           autocomplete="off"
+                                           onChange={v => setFieldValue('password', v)}/>
 
-                                <div style={{ marginTop: '32px' }}>
-                                    <Button size="large"
-                                            type="primary"
-                                            block={true}
-                                            disabled={isSubmitting}
-                                            onClick={submitForm}>
-                                        Sign Up
-                                    </Button>
-                                </div>
-                                <BottomTray>
-                                    <Link to={LOGIN}>Login</Link>
-                                    <Link to={REQUEST_RESET}>Reset Password</Link>
-                                </BottomTray>
+                                    <div style={{ marginTop: '32px' }}>
+                                        <Button size="large"
+                                                htmlType="submit"
+                                                type="primary"
+                                                block={true}
+                                                disabled={isSubmitting}>
+                                            Sign Up
+                                        </Button>
+                                    </div>
+                                    <BottomTray>
+                                        <Link to={LOGIN}>Login</Link>
+                                        <Link to={REQUEST_RESET}>Reset Password</Link>
+                                    </BottomTray>
+                                </Form>
                             </Box>
                         </AuthWrapper>
                     </AuthPage>

--- a/src/app/Auth/RequestReset.tsx
+++ b/src/app/Auth/RequestReset.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as Yup from 'yup';
 import { Button } from 'antd';
-import { Formik, FormikProps } from 'formik';
+import { Formik, FormikProps, Form } from 'formik';
 
 import { LOGIN } from "routes";
 import { RequestResetSpecs } from "./types";
@@ -33,29 +33,31 @@ const RequestReset: React.FC<RequestResetSpecs.Props> = ({ requestReset, history
         })}
     >
         {(props: FormikProps<RequestResetSpecs.FormValues>) => {
-            const { values, errors, setFieldValue, submitForm, submitCount, isSubmitting } = props;
+            const { values, errors, setFieldValue, submitCount, isSubmitting } = props;
             const wasSubmitted = submitCount > 0;
 
             return (
                 <AuthPage>
                     <AuthWrapper>
                         <Box>
-                            <h1>Password Reset</h1>
-                            <Input label="Email"
-                                   value={values.email}
-                                   error={wasSubmitted && !!errors.email}
-                                   errorMsg={errors.email}
-                                   onChange={v => setFieldValue('email', v)}/>
+                            <Form>
+                                <h1>Password Reset</h1>
+                                <Input label="Email"
+                                       value={values.email}
+                                       error={wasSubmitted && !!errors.email}
+                                       errorMsg={errors.email}
+                                       onChange={v => setFieldValue('email', v)}/>
 
-                            <div style={{ marginTop: '32px' }}>
-                                <Button size="large"
-                                        type="primary"
-                                        block={true}
-                                        disabled={isSubmitting}
-                                        onClick={submitForm}>
-                                    Reset Password
-                                </Button>
-                            </div>
+                                <div style={{ marginTop: '32px' }}>
+                                    <Button size="large"
+                                            htmlType="submit"
+                                            type="primary"
+                                            block={true}
+                                            disabled={isSubmitting}>
+                                        Reset Password
+                                    </Button>
+                                </div>
+                            </Form>
                         </Box>
                     </AuthWrapper>
                 </AuthPage>

--- a/src/app/Auth/ResetPassword.tsx
+++ b/src/app/Auth/ResetPassword.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as Yup from 'yup';
 import { Alert, Button } from 'antd';
-import { Formik, FormikProps } from 'formik';
+import { Formik, FormikProps, Form } from 'formik';
 
 import { LOGIN } from "routes";
 import { ResetPasswordSpecs } from "./types";
@@ -42,7 +42,7 @@ const ResetPassword: React.FC<ResetPasswordSpecs.Props> = ({ resetPassword, hist
             })}
         >
             {(props: FormikProps<ResetPasswordSpecs.FormValues>) => {
-                const { values, errors, setFieldValue, submitForm, submitCount, isSubmitting } = props;
+                const { values, errors, setFieldValue, submitCount, isSubmitting } = props;
                 const wasSubmitted = submitCount > 0;
                 setMatchError(wasSubmitted && values.password !== values.confirmPassword);
 
@@ -55,31 +55,33 @@ const ResetPassword: React.FC<ResetPasswordSpecs.Props> = ({ resetPassword, hist
                                     <Alert message="Passwords do not match." type="error"
                                            style={{ marginBottom: '16px' }}/>
                                 )}
-                                <Input label="New Password"
-                                       type="password"
-                                       value={values.password}
-                                       error={wasSubmitted && !!errors.password}
-                                       errorMsg={errors.password}
-                                       autocomplete="new-password"
-                                       onChange={v => setFieldValue('password', v)}/>
+                                <Form>
+                                    <Input label="New Password"
+                                           type="password"
+                                           value={values.password}
+                                           error={wasSubmitted && !!errors.password}
+                                           errorMsg={errors.password}
+                                           autocomplete="new-password"
+                                           onChange={v => setFieldValue('password', v)}/>
 
-                                <Input label="Repeat New Password"
-                                       type="password"
-                                       value={values.confirmPassword}
-                                       error={wasSubmitted && !!errors.confirmPassword}
-                                       errorMsg={errors.confirmPassword}
-                                       autocomplete="new-password"
-                                       onChange={v => setFieldValue('confirmPassword', v)}/>
+                                    <Input label="Repeat New Password"
+                                           type="password"
+                                           value={values.confirmPassword}
+                                           error={wasSubmitted && !!errors.confirmPassword}
+                                           errorMsg={errors.confirmPassword}
+                                           autocomplete="new-password"
+                                           onChange={v => setFieldValue('confirmPassword', v)}/>
 
-                                <div style={{ marginTop: '32px' }}>
-                                    <Button size="large"
-                                            type="primary"
-                                            block={true}
-                                            disabled={isSubmitting}
-                                            onClick={submitForm}>
-                                        Reset Password
-                                    </Button>
-                                </div>
+                                    <div style={{ marginTop: '32px' }}>
+                                        <Button size="large"
+                                                htmlType="submit"
+                                                type="primary"
+                                                block={true}
+                                                disabled={isSubmitting}>
+                                            Reset Password
+                                        </Button>
+                                    </div>
+                                </Form>
                             </Box>
                         </AuthWrapper>
                     </AuthPage>


### PR DESCRIPTION
This PR works on Login, Register, RequestReset and ResetPassword forms.
* Ability to submit by clicking Enter: is very convenient and a pretty standard feature
* Bottom margin in alerts: it looks better. I applied the same style as in `src/app/Auth/ResetPassword.tsx`