### PR TITLE
Improve Auth forms

### DIFF
--- a/src/app/Auth/Login.tsx
+++ b/src/app/Auth/Login.tsx
@@ -66,6 +66,7 @@ export const Login: FC = () => {
                   <Alert
                     message="Invalid email/username or password. Please try again."
                     type="error"
+                    style={{ marginBottom: '16px' }}
                   />
                 )}
                 <Input

--- a/src/app/Auth/Login.tsx
+++ b/src/app/Auth/Login.tsx
@@ -3,7 +3,7 @@ import * as Yup from "yup"
 import { useHistory } from "react-router"
 import { Link } from "react-router-dom"
 import { Button, Alert } from "antd"
-import { Formik, FormikProps } from "formik"
+import { Formik, FormikProps, Form } from "formik"
 
 import { INVENTORY, REQUEST_RESET, REGISTER } from "routes"
 
@@ -51,7 +51,6 @@ export const Login: FC = () => {
           values,
           errors,
           setFieldValue,
-          submitForm,
           submitCount,
           isSubmitting,
         } = props
@@ -69,41 +68,43 @@ export const Login: FC = () => {
                     style={{ marginBottom: '16px' }}
                   />
                 )}
-                <Input
-                  label="Email/Username"
-                  value={values.emailOrUsername}
-                  error={wasSubmitted && !!errors.emailOrUsername}
-                  errorMsg={errors.emailOrUsername}
-                  autocomplete="emailOrUsername"
-                  onChange={(v) => setFieldValue("emailOrUsername", v)}
-                />
+                <Form>
+                  <Input
+                    label="Email/Username"
+                    value={values.emailOrUsername}
+                    error={wasSubmitted && !!errors.emailOrUsername}
+                    errorMsg={errors.emailOrUsername}
+                    autocomplete="emailOrUsername"
+                    onChange={(v) => setFieldValue("emailOrUsername", v)}
+                  />
 
-                <Input
-                  label="Password"
-                  value={values.password}
-                  error={wasSubmitted && !!errors.password}
-                  errorMsg={errors.password}
-                  autocomplete="current-password"
-                  onChange={(v) => setFieldValue("password", v)}
-                  type="password"
-                />
+                  <Input
+                    label="Password"
+                    value={values.password}
+                    error={wasSubmitted && !!errors.password}
+                    errorMsg={errors.password}
+                    autocomplete="current-password"
+                    onChange={(v) => setFieldValue("password", v)}
+                    type="password"
+                  />
 
-                <div style={{ marginTop: "32px" }}>
-                  <Button
-                    size="large"
-                    type="primary"
-                    block={true}
-                    disabled={isSubmitting}
-                    onClick={submitForm}
-                  >
-                    Sign In
-                  </Button>
-                </div>
+                  <div style={{ marginTop: "32px" }}>
+                    <Button
+                      size="large"
+                      type="primary"
+                      block={true}
+                      disabled={isSubmitting}
+                      htmlType="submit"
+                    >
+                      Sign In
+                    </Button>
+                  </div>
 
-                <BottomTray>
-                  <Link to={REGISTER}>Register</Link>
-                  <Link to={REQUEST_RESET}>Reset Password</Link>
-                </BottomTray>
+                  <BottomTray>
+                    <Link to={REGISTER}>Register</Link>
+                    <Link to={REQUEST_RESET}>Reset Password</Link>
+                  </BottomTray>
+                </Form>
               </Box>
             </AuthWrapper>
           </AuthPage>

--- a/src/app/Auth/Register.tsx
+++ b/src/app/Auth/Register.tsx
@@ -70,6 +70,7 @@ export const Register: FC = () => {
                   <Alert
                     message="Username/email already registered. Please login."
                     type="error"
+                    style={{ marginBottom: '16px' }}
                   />
                 )}
                 <Input

--- a/src/app/Auth/Register.tsx
+++ b/src/app/Auth/Register.tsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom"
 import { useHistory } from "react-router"
 
 import { Button, Alert } from "antd"
-import { Formik, FormikProps } from "formik"
+import { Formik, FormikProps, Form } from "formik"
 
 import { INVENTORY, LOGIN, REQUEST_RESET } from "routes"
 import { useUserRegister } from "queries/user"
@@ -55,7 +55,6 @@ export const Register: FC = () => {
           values,
           errors,
           setFieldValue,
-          submitForm,
           submitCount,
           isSubmitting,
         } = props
@@ -73,49 +72,51 @@ export const Register: FC = () => {
                     style={{ marginBottom: '16px' }}
                   />
                 )}
-                <Input
-                  label="Username"
-                  value={values.username}
-                  error={wasSubmitted && !!errors.username}
-                  errorMsg={errors.username}
-                  autocomplete="off"
-                  onChange={(v) => setFieldValue("username", v)}
-                />
+                <Form>
+                  <Input
+                    label="Username"
+                    value={values.username}
+                    error={wasSubmitted && !!errors.username}
+                    errorMsg={errors.username}
+                    autocomplete="off"
+                    onChange={(v) => setFieldValue("username", v)}
+                  />
 
-                <Input
-                  label="Email"
-                  value={values.email}
-                  error={wasSubmitted && !!errors.email}
-                  errorMsg={errors.email}
-                  autocomplete="off"
-                  onChange={(v) => setFieldValue("email", v)}
-                />
+                  <Input
+                    label="Email"
+                    value={values.email}
+                    error={wasSubmitted && !!errors.email}
+                    errorMsg={errors.email}
+                    autocomplete="off"
+                    onChange={(v) => setFieldValue("email", v)}
+                  />
 
-                <Input
-                  label="Password"
-                  value={values.password}
-                  type="password"
-                  error={wasSubmitted && !!errors.password}
-                  errorMsg={errors.password}
-                  autocomplete="off"
-                  onChange={(v) => setFieldValue("password", v)}
-                />
+                  <Input
+                    label="Password"
+                    value={values.password}
+                    type="password"
+                    error={wasSubmitted && !!errors.password}
+                    errorMsg={errors.password}
+                    autocomplete="off"
+                    onChange={(v) => setFieldValue("password", v)}
+                  />
 
-                <div style={{ marginTop: "32px" }}>
-                  <Button
-                    size="large"
-                    type="primary"
-                    block={true}
-                    disabled={isSubmitting}
-                    onClick={submitForm}
-                  >
-                    Sign Up
-                  </Button>
-                </div>
-                <BottomTray>
-                  <Link to={LOGIN}>Login</Link>
-                  <Link to={REQUEST_RESET}>Reset Password</Link>
-                </BottomTray>
+                  <div style={{ marginTop: "32px" }}>
+                    <Button
+                      size="large"
+                      type="primary"
+                      block={true}
+                      disabled={isSubmitting}
+                      htmlType="submit"
+                    >
+                      Sign Up
+                    </Button>
+                  </div>
+                  <BottomTray>
+                    <Link to={LOGIN}>Login</Link>
+                    <Link to={REQUEST_RESET}>Reset Password</Link>
+                  </BottomTray>
+                </Form>
               </Box>
             </AuthWrapper>
           </AuthPage>

--- a/src/app/Auth/RequestReset.tsx
+++ b/src/app/Auth/RequestReset.tsx
@@ -2,7 +2,7 @@ import { FC } from "react"
 import * as Yup from "yup"
 import { Button } from "antd"
 import { useHistory } from "react-router"
-import { Formik, FormikProps } from "formik"
+import { Formik, FormikProps, Form } from "formik"
 
 import { LOGIN } from "routes"
 import { requestPasswordReset } from "api/api"
@@ -42,7 +42,6 @@ export const RequestReset: FC = () => {
           values,
           errors,
           setFieldValue,
-          submitForm,
           submitCount,
           isSubmitting,
         } = props
@@ -52,26 +51,28 @@ export const RequestReset: FC = () => {
           <AuthPage>
             <AuthWrapper>
               <Box>
-                <h1>Password Reset</h1>
-                <Input
-                  label="Email"
-                  value={values.email}
-                  error={wasSubmitted && !!errors.email}
-                  errorMsg={errors.email}
-                  onChange={(v) => setFieldValue("email", v)}
-                />
+                <Form>
+                  <h1>Password Reset</h1>
+                  <Input
+                    label="Email"
+                    value={values.email}
+                    error={wasSubmitted && !!errors.email}
+                    errorMsg={errors.email}
+                    onChange={(v) => setFieldValue("email", v)}
+                  />
 
-                <div style={{ marginTop: "32px" }}>
-                  <Button
-                    size="large"
-                    type="primary"
-                    block={true}
-                    disabled={isSubmitting}
-                    onClick={submitForm}
-                  >
-                    Reset Password
-                  </Button>
-                </div>
+                  <div style={{ marginTop: "32px" }}>
+                    <Button
+                      size="large"
+                      type="primary"
+                      block={true}
+                      disabled={isSubmitting}
+                      htmlType="submit"
+                    >
+                      Reset Password
+                    </Button>
+                  </div>
+                </Form>
               </Box>
             </AuthWrapper>
           </AuthPage>

--- a/src/app/Auth/ResetPassword.tsx
+++ b/src/app/Auth/ResetPassword.tsx
@@ -2,7 +2,7 @@ import { useState, FC } from "react"
 import * as Yup from "yup"
 import { Alert, Button } from "antd"
 import { useHistory, useLocation } from "react-router"
-import { Formik, FormikProps } from "formik"
+import { Formik, FormikProps, Form } from "formik"
 
 import { LOGIN } from "routes"
 import { resetPassword } from "api/api"
@@ -57,7 +57,6 @@ export const ResetPassword: FC = () => {
           values,
           errors,
           setFieldValue,
-          submitForm,
           submitCount,
           isSubmitting,
         } = props
@@ -70,45 +69,47 @@ export const ResetPassword: FC = () => {
           <AuthPage>
             <AuthWrapper>
               <Box>
-                <h1>Password Reset</h1>
-                {matchError && (
-                  <Alert
-                    message="Passwords do not match."
-                    type="error"
-                    style={{ marginBottom: "16px" }}
+                <Form>
+                  <h1>Password Reset</h1>
+                  {matchError && (
+                    <Alert
+                      message="Passwords do not match."
+                      type="error"
+                      style={{ marginBottom: "16px" }}
+                    />
+                  )}
+                  <Input
+                    label="New Password"
+                    type="password"
+                    value={values.password}
+                    error={wasSubmitted && !!errors.password}
+                    errorMsg={errors.password}
+                    autocomplete="new-password"
+                    onChange={(v) => setFieldValue("password", v)}
                   />
-                )}
-                <Input
-                  label="New Password"
-                  type="password"
-                  value={values.password}
-                  error={wasSubmitted && !!errors.password}
-                  errorMsg={errors.password}
-                  autocomplete="new-password"
-                  onChange={(v) => setFieldValue("password", v)}
-                />
 
-                <Input
-                  label="Repeat New Password"
-                  type="password"
-                  value={values.confirmPassword}
-                  error={wasSubmitted && !!errors.confirmPassword}
-                  errorMsg={errors.confirmPassword}
-                  autocomplete="new-password"
-                  onChange={(v) => setFieldValue("confirmPassword", v)}
-                />
+                  <Input
+                    label="Repeat New Password"
+                    type="password"
+                    value={values.confirmPassword}
+                    error={wasSubmitted && !!errors.confirmPassword}
+                    errorMsg={errors.confirmPassword}
+                    autocomplete="new-password"
+                    onChange={(v) => setFieldValue("confirmPassword", v)}
+                  />
 
-                <div style={{ marginTop: "32px" }}>
-                  <Button
-                    size="large"
-                    type="primary"
-                    block={true}
-                    disabled={isSubmitting}
-                    onClick={submitForm}
-                  >
-                    Reset Password
-                  </Button>
-                </div>
+                  <div style={{ marginTop: "32px" }}>
+                    <Button
+                      size="large"
+                      type="primary"
+                      block={true}
+                      disabled={isSubmitting}
+                      htmlType="submit"
+                    >
+                      Reset Password
+                    </Button>
+                  </div>
+                </Form>
               </Box>
             </AuthWrapper>
           </AuthPage>


### PR DESCRIPTION
This PR works on Login, Register, RequestReset and ResetPassword forms.
* Ability to submit by clicking Enter: is very convenient and a pretty standard feature
* Bottom margin in alerts: it looks better. I applied the same style as in `src/app/Auth/ResetPassword.tsx`